### PR TITLE
travis: bump go to 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 
 go:
-    - 1.7
+    - 1.7.3
 
 services:
     -  docker


### PR DESCRIPTION
This PR updates go to [version 1.7.3](https://github.com/golang/go/releases/tag/go1.7.3) on travis.
