### PR TITLE
Dockerfile builds everything on the same step to avoid big intermediate layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,13 @@
-FROM golang:1.7-alpine
+FROM alpine:latest
 
-RUN apk add --update git && rm -rf /var/cache/apk/*
+ENV GOPATH /go
 
-#Dependencies
-RUN go get github.com/gorilla/mux
-
-COPY . $GOPATH
-
-RUN go get -d -v github.com/MarcosSegovia/MyWins/src
-RUN go install github.com/MarcosSegovia/MyWins/src
-
-WORKDIR $GOPATH/src/github.com/MarcosSegovia/MyWins
-RUN go build -o mywins src/*.go
-
-CMD $GOPATH/mywins
+RUN apk add --update git go && \
+    git clone https://github.com/MarcosSegovia/MyWins.git /go/src/github.com/MarcosSegovia/MyWins &&\
+    cd /go/src/github.com/MarcosSegovia/MyWins/src &&\
+    go get && go build -o /mywins &&\
+    apk del go git &&\
+    rm -fr /go
 
 EXPOSE 8080
-
-
+CMD ["/mywins"]


### PR DESCRIPTION
Closes #1 

I used the alpine image as base instead of the golang one, and put everything on the same RUN step, so docker doesnt hold any extra space.

It also grabs the source code from the repo directly instead of building from the local context, so you could distribute the Dockerfile only, although it could be reverted do the COPY again and be able to build it offline.

Now its just 14.16MiB :)
